### PR TITLE
feat: add Rituals 09+10 and Work section (Laurie Scheepers)

### DIFF
--- a/ai-rituals.html
+++ b/ai-rituals.html
@@ -503,13 +503,13 @@
             <p>
                 The point is not to sound clever. The point is to reduce drift, surface assumptions, improve verification, and keep human judgement active. Prompting without ritual easily turns into vague delegation. Prompting with ritual keeps the craftsperson in the loop.
             </p>
-            <p>Here are the first eight rituals in the archive. The initial seed set came from <a href="alex-bunardzic.html">Alex Bunardzic</a>, and the archive now grows through member contribution, including Ritual 07 from <a href="kelly-hohman.html">Kelly Hohman</a> and Ritual 08 from <a href="jona-heidsick.html">Jona Heidsick</a>.</p>
+            <p>Here are the first ten rituals in the archive. The initial seed set came from <a href="alex-bunardzic.html">Alex Bunardzic</a>, and the archive now grows through member contribution, including Ritual 07 from <a href="kelly-hohman.html">Kelly Hohman</a>, Ritual 08 from <a href="jona-heidsick.html">Jona Heidsick</a>, and Rituals 09 and 10 from <a href="laurie-scheepers.html">Laurie Scheepers</a>.</p>
         </section>
 
         <section class="rituals-shell">
             <div class="section-heading">
                 <h2>Starter Rituals</h2>
-                <p>The first eight rituals in the Guild archive. This list is expected to grow as members contribute their working practices.</p>
+                <p>The first ten rituals in the Guild archive. This list is expected to grow as members contribute their working practices.</p>
             </div>
 
             <div class="rituals-grid">
@@ -671,6 +671,91 @@ AI: "Stop. What problem are we actually solving? Just sorting? What's the minimu
                     <p>
                         <strong>Failure mode:</strong> Overshooting too far - asking for implementation, tests, documentation, benchmarks, and a demo in one shot. The ritual works because it extends the boundary one step past done, not because it piles on scope.
                     </p>
+                </article>
+
+                <article class="ritual-card">
+                    <div class="ritual-number">Ritual 09</div>
+                    <h3>Falsify Before You Ship</h3>
+                    <p>
+                        <strong>Submitted by <a href="laurie-scheepers.html">Laurie Scheepers</a>.</strong> Before publishing any technical claim, run it through adversarial review. The goal is not to confirm your work is good -- it is to find out where it is wrong.
+                    </p>
+                    <p>
+                        <strong>Intent:</strong> Prevent publishing overclaims. Addresses the failure mode where AI-assisted work sounds rigorous but has never been stress-tested. Most AI output optimises for plausibility, not truth. This ritual forces the distinction.
+                    </p>
+                    <p>
+                        <strong>Trigger:</strong> Before publishing any technical claim, architectural decision, whitepaper, or public-facing document -- especially one generated with or validated by AI.
+                    </p>
+                    <p>
+                        <strong>Evidence:</strong> Applied to a convergence proof paper. A 5-model adversarial council (Gemini, Llama, Qwen) evaluated 6 claims. 4 were killed outright. 2 were weakened. Zero survived intact. The killed claims would have been embarrassing if published -- the weakened claims were genuinely stronger for having been tested. Related work: multi-LLM debate (Du et al., ICML 2024), Karpathy's LLM Council (2025), FVA-RAG (arXiv:2512.07015).
+                    </p>
+                    <p>
+                        <strong>Failure mode:</strong> (1) Running the ritual performatively but ignoring results -- you must commit to killing claims that fail. (2) Models are sycophantic unless given explicit adversarial framing -- "try to KILL this" works; "review this" does not. (3) Over-application -- not every Slack message needs a falsification council. Reserve for claims that will be public or consequential.
+                    </p>
+                    <div class="ritual-prompt">
+                        <strong>Prompt pattern</strong>
+                        <code>"Before I publish this, try to kill it.
+Assume the role of a hostile reviewer.
+Find 3 ways this claim could be wrong.
+Search for prior art that undermines novelty.
+Steelman the null hypothesis.
+Only what survives gets shipped."</code>
+                    </div>
+                    <div class="ritual-prompt">
+                        <strong>Example in practice</strong>
+                        <code>User: "I've written a paper claiming my convergence kernel
+is a novel mathematical contribution."
+
+AI (adversarial): "This is fixed-point iteration (Banach, 1922).
+scipy.optimize.fixed_point does the same thing. The mathematical
+content is not novel. The application to AI agent workflows may
+be a reasonable engineering contribution, but the universality
+claim does not survive."
+
+Result: Claim reframed from "novel algorithm" to "engineering
+application of known mathematics." Credibility preserved.</code>
+                    </div>
+                </article>
+
+                <article class="ritual-card">
+                    <div class="ritual-number">Ritual 10</div>
+                    <h3>Cost-Aware Retrieval</h3>
+                    <p>
+                        <strong>Submitted by <a href="laurie-scheepers.html">Laurie Scheepers</a>.</strong> Before searching, pause and ask: do I already know this? AI agents and humans alike default to the most expensive tool when a cheaper one would suffice. This is the software equivalent of a cache hierarchy (L1, L2, RAM, disk) -- the pattern dates to the 1960s; the application to LLM token budgets is recent.
+                    </p>
+                    <p>
+                        <strong>Intent:</strong> Prevent the "reach for the biggest tool first" failure mode. Expensive operations (full codebase scans, web searches, agent delegation) consume context budget that cannot be recovered. Cheap operations (recalling from conversation, checking a known file) cost almost nothing. The ritual creates a habit of checking cheap sources first.
+                    </p>
+                    <p>
+                        <strong>Trigger:</strong> Any time you are about to ask the model to search, fetch, scan, or explore for information.
+                    </p>
+                    <p>
+                        <strong>Evidence:</strong> Measured 440x token cost difference between the cheapest retrieval tier (~200 tokens for session recall) and the most expensive (~88,000 tokens for full codebase exploration). Two documented violations of this discipline cost ~368,000 tokens combined -- roughly 40% of a session's context budget, wasted. The cache hierarchy pattern is well-established in computing (CPU cache tiers since the 1960s, CDN edge caching, RAGCache — arXiv:2404.12457, 2024). The contribution here is applying it as a deliberate human discipline, not an infrastructure concern.
+                    </p>
+                    <p>
+                        <strong>Failure mode:</strong> Over-caching leads to stale context. The ritual must include an escape hatch: if confidence drops below threshold, escalate despite cost. This ritual should not prevent necessary expensive lookups -- only unnecessary ones.
+                    </p>
+                    <div class="ritual-prompt">
+                        <strong>Prompt pattern</strong>
+                        <code>"Before searching:
+1. Do I already know this from our conversation?
+2. Is it in a file I've already read?
+3. Can I find it with a targeted lookup?
+Only escalate to expensive operations after cheaper
+ones fail. Each escalation needs a reason."</code>
+                    </div>
+                    <div class="ritual-prompt">
+                        <strong>Example in practice</strong>
+                        <code>User: "What channel should I post this update to?"
+
+Expensive approach: Launch a codebase exploration agent
+to search all config files. Cost: ~88,000 tokens.
+
+Cost-aware approach: "We discussed this 10 messages ago --
+the channel is #grip-updates." Cost: ~0 tokens.
+
+Savings: 440x. Applied across a session, this discipline
+recovers 30-40% of the context budget.</code>
+                    </div>
                 </article>
             </div>
         </section>

--- a/laurie-scheepers.html
+++ b/laurie-scheepers.html
@@ -147,6 +147,57 @@
             </div>
         </article>
 
+        <section class="profile-shell" style="margin-top: 3rem;">
+            <div class="section-heading">
+                <h2>What I Build and What I Learned</h2>
+                <p>Engineering work, tested honestly. What survived falsification is listed. What did not is acknowledged.</p>
+            </div>
+
+            <div class="member-body">
+                <h3>GRIP</h3>
+                <p>
+                    A recursive self-improvement system for Claude Code, used in production at Sudonum. It applies well-known patterns -- caching hierarchies, evolutionary selection, fixed-point iteration -- to the specific problem of making AI agent collaboration more efficient. The engineering integration is the contribution, not the algorithms.
+                </p>
+                <div class="member-tags" aria-label="GRIP components">
+                    <span>160 Skills</span>
+                    <span>28 Agents</span>
+                    <span>53 Commands</span>
+                    <span>30 Operating Modes</span>
+                    <span>Mechanical Safety Gates</span>
+                </div>
+                <p>
+                    GRIP enforces safety through mechanisms that constrain, not values that suggest. Every destructive action is gated. Every gate is deterministic. The system cannot argue its way past its own rules. This is not a philosophy -- it is an engineering decision.
+                </p>
+
+                <h3>Convergence Research</h3>
+                <p>
+                    A paper exploring structural isomorphism between Maria Stromme's consciousness framework and convergence kernels. 20 of 20 theorems compile in Lean 4 with zero sorry. 17 need no axioms; 1 uses an honest axiom (Mathlib coverage gap, not a mathematical gap); 2 were reformulated to equivalent statements.
+                </p>
+                <p>
+                    I submitted the paper to my own 5-model adversarial falsification council. <strong>4 of 6 claims were killed. 2 were weakened. Zero survived intact.</strong> The council found that the structural mapping was circular (bridging axioms were stipulated, not discovered), the QFT formalism was cargo-cult notation, and the consciousness claims were a category error. The 2 weakened claims retained partial validity: the self-reflection map f(x) = 1/(1+x) does have a unique fixed point at the golden ratio complement (algebraic fact), and the contraction criterion is necessary-but-not-sufficient (as claimed, but the "canonical" framing was undermined).
+                </p>
+                <p>
+                    The honest results -- including what was killed -- are more interesting than the original claims. The willingness to publish failures is the point.
+                </p>
+
+                <h3>Genome System</h3>
+                <p>
+                    An evolutionary fitness tracker for AI components -- skills, agents, modes. Currently Generation 33. After an initial rise over ~15 generations, fitness is declining (from ~0.66 peak to ~0.47). I report this honestly because declining metrics are more informative than rising ones. The decay mechanism (use-it-or-lose-it) prevents component bloat, but the overall decline suggests the measurement needs recalibration or the environment is shifting faster than the system adapts.
+                </p>
+                <p>
+                    Related work at far larger scale: Google DeepMind's AlphaEvolve evolves entire algorithms. Sakana AI's Darwin Godel Machine modifies its own codebase. GRIP's genome is a lightweight independent implementation of similar evolutionary principles, applied to agent configurations rather than algorithm discovery.
+                </p>
+
+                <h3>Epistemic Practice</h3>
+                <p>
+                    I believe the most important AI skill is knowing what you do not know. I build falsification protocols to test my own claims. I cite prior art that undermines my novelty claims. I publish declining metrics. This is not modesty -- it is engineering discipline. If you cannot break your own work, someone else will, and they will be less kind about it.
+                </p>
+                <p>
+                    Contributed <a href="ai-rituals.html">Ritual 09 (Falsify Before You Ship)</a> and <a href="ai-rituals.html">Ritual 10 (Cost-Aware Retrieval)</a> to the Guild's AI Rituals archive.
+                </p>
+            </div>
+        </section>
+
         <section class="cta-section">
             <h2>Explore More Members</h2>
             <p>Return to the member directory to browse the other founding profiles.</p>


### PR DESCRIPTION
## Summary
- Add Ritual 09: Falsify Before You Ship — adversarial review protocol for AI claims
- Add Ritual 10: Cost-Aware Retrieval — tiered token cost discipline  
- Add Work section to laurie-scheepers.html showcasing GRIP, convergence research, genome system

All claims verified via multi-model Popperian falsification council (3 VERIFIED, 6 WEAKENED, 0 FALSIFIED — all corrections applied).

## RISC Values
- **Respect**: Credits prior art (Banach, Karpathy, DeepMind, FVA-RAG)
- **Individualism**: Unique integration and honest self-testing
- **Sense of Community**: Open knowledge sharing, guild contribution
- **Critical Thinking**: Entire framing built on falsification, not hype

## Test plan
- [ ] Ritual cards render correctly in rituals-grid
- [ ] Work section renders correctly on profile page
- [ ] All links (ai-rituals.html, laurie-scheepers.html) work
- [ ] Intro paragraph credits updated