### PR TITLE
Add CONTRIBUTING.md and Claude Code project context

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,53 @@
+# AI Craftspeople Guild — Project Context
+
+This is the AI Craftspeople Guild's website, hosted on GitHub Pages.
+
+## What This Repo Contains
+
+Static HTML pages for the Guild's public presence:
+
+- Member profiles and directory
+- The 10 Rituals for human-AI collaboration
+- Guild manifesto, charter, and code of conduct
+- White papers and thought leadership
+- Showcases and demonstration content
+- Guild Radar (trend detection)
+
+## Architecture
+
+- Pure static HTML + CSS (no build step, no framework)
+- Hosted via GitHub Pages on the `main` branch
+- Content is added via GitHub web interface or PRs
+- No JavaScript dependencies
+
+## Key Files
+
+| File | What It Is |
+|------|-----------|
+| `index.html` | Landing page with manifesto signing |
+| `ai-rituals.html` | The 10 Guild Rituals |
+| `members.html` | Member directory |
+| `charter.html` | Governance structure |
+| `code-of-conduct.html` | Professional and epistemic standards |
+| `showcases.html` | Live demonstrations |
+| `guild-radar.html` | Trend detection system |
+
+## Contributing
+
+See `CONTRIBUTING.md` for how to contribute. Short version: open a PR, use the
+GitHub web interface, or send your content to a maintainer. Follow whatever
+best practices you know.
+
+## Guild Principles
+
+- Claims require evidence (reproducible demos, cited sources, or qualifiers)
+- Failures are valued contributions
+- No unverified AI outputs shipped without human review
+- Round table structure — equal voice for all members
+
+## Related Repos
+
+- [ACGCLI](https://github.com/teslasolar/ACGCLI) — Universal project wrapper by Thomas
+- [Guild Flywheel](https://github.com/Mysticbirdie/Guild) — Discipline framework by Kelly
+- [ACG Repo Template](https://github.com/teslasolar/ACG_Repo_Template) — Member page template
+- [CodeTonight Guild Page](https://github.com/CodeTonight-SA/guild) — CodeTonight's member page

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing to the AI Craftspeople Guild
+
+Welcome. If you're here, you care about building AI with craft. That's the only requirement.
+
+## Ways to Contribute
+
+There's no single right way. Pick whatever feels natural:
+
+- **Open a Pull Request** — if you're comfortable with git, PRs are a great way to
+  propose changes. Fork the repo, make your changes, and submit a PR.
+- **Use the GitHub web interface** — click "Add file" or edit any file directly in the
+  browser. GitHub creates the PR for you. No git knowledge needed.
+- **Send your content to a maintainer** — if you'd rather focus on the thinking and let
+  someone else handle the implementation, that works too. Reach out on Discord.
+- **Open an issue** — have an idea but not sure how to implement it? Open an issue
+  describing what you're thinking. Discussion is contribution.
+
+## What Counts as a Contribution
+
+Anything that makes the Guild better for its members:
+
+- Writing or improving pages, articles, or documentation
+- Adding your member profile
+- Proposing or refining rituals
+- Sharing case studies, war stories, or experiments
+- Fixing typos, broken links, or formatting issues
+- Suggesting structural improvements
+- Building tools that serve the Guild community
+
+## Quality Expectations
+
+Follow whatever best practices you know and work with. The Guild values craft,
+which means different things to different people — and that's fine.
+
+A few things the Guild cares about (from the Code of Conduct):
+
+- **Claims need evidence** — if you're stating something about AI capabilities,
+  include how you know. A demo, a citation, or an honest "in my experience" qualifier.
+- **Failures are welcome** — sharing what didn't work is as valuable as sharing
+  what did. Maybe more.
+- **No AI slop** — human review before publication. The output should reflect care.
+
+## Review Process
+
+Maintainers will review PRs. For content additions, the bar is: does this add
+value for Guild members? For code changes, the bar is: does this work and does
+it not break what's already there?
+
+If your PR needs changes, you'll get clear feedback. No gatekeeping — just craft.
+
+## Questions?
+
+Ask on the Guild Discord, or open an issue here. There are no stupid questions.
+
+---
+
+*"We are craftspeople who chose to build with purpose and integrity."*


### PR DESCRIPTION
## Summary

- Adds `CONTRIBUTING.md` — gentle, non-prescriptive guide for how Guild members can contribute. Addresses questions raised by Nicolas and others about the contribution process. Multiple paths documented (PRs, web interface, sending content to maintainers, opening issues). No strict rules — follow your own best practices.
- Adds `.claude/CLAUDE.md` — project context file for Claude Code users working on this repo. Documents the site structure, key files, and related repos.

Both files are **purely additive** — no changes to any existing files.

Relates to #3

## What This Enables

- New members can find clear (but flexible) guidance on how to contribute
- Claude Code users get project context automatically when working in this repo
- The contribution process is documented without being prescriptive

## Test Plan

- [ ] Verify CONTRIBUTING.md renders correctly on GitHub
- [ ] Verify .claude/CLAUDE.md is accurate to the current repo structure
- [ ] Confirm no existing files were modified