### PR TITLE
feat: MQTT pub/sub over WebRTC mesh + acg-mcp server

### DIFF
--- a/bin/acg-mcp.py
+++ b/bin/acg-mcp.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""
+acg-mcp — Model Context Protocol server exposing the ACG control plane.
+
+Lets an external agent read/write the GitHub-Issues tag DB, fire
+state-machine events, list scripts, and invoke control-deck actions
+through a typed tool schema — the same surface the README buttons
+give a human.
+
+Transport: stdio, newline-delimited JSON-RPC 2.0 (standard MCP stdio
+transport). Zero dependencies — stdlib only.
+
+Tools
+-----
+  tag_read(path)
+  tag_write(path, value, type?, quality?, description?)
+  list_tags()
+  fire_event(tag, from_state?, to_state?, kind?)
+  list_scripts(tag?)
+  list_actions()
+  cmd_action(id)         -- files an issue that the cmd workflow runs
+  site_base()
+  peek_api(url?)         -- HEAD-probe a public endpoint
+
+Install
+-------
+Add to ~/.config/claude-desktop.json (or similar):
+  {
+    "mcpServers": {
+      "acg": {
+        "command": "python",
+        "args": ["<REPO>/bin/acg-mcp.py"],
+        "env": {"GITHUB_TOKEN": "ghp_..."}
+      }
+    }
+  }
+
+See docs/engineering/acg-mcp.md for full setup + examples.
+"""
+import io, json, os, sys, traceback
+from pathlib import Path
+
+# MCP stdio transport REQUIRES utf-8; Windows consoles default to cp1252
+# which chokes on any emoji/unicode in tool output. Rewrap stdio before
+# anything else touches it.
+try:
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8",
+                                  write_through=True, newline="")
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8",
+                                  write_through=True, newline="")
+    sys.stdin  = io.TextIOWrapper(sys.stdin.buffer,  encoding="utf-8",
+                                  newline="")
+except Exception:
+    pass
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "guild" / "Enterprise" / "L2" / "lib"))
+
+import gh_tag  # noqa: E402
+try:
+    import site_base  # noqa: E402
+except ImportError:
+    site_base = None
+
+PROTOCOL_VERSION = "2024-11-05"
+SERVER_NAME      = "acg"
+SERVER_VERSION   = "0.1.0"
+
+
+# ─── helpers ────────────────────────────────────────────────────────
+
+def _base() -> str:
+    if site_base:
+        return site_base.site_base()
+    return "https://aicraftspeopleguild.github.io"
+
+
+def _text_result(text: str) -> dict:
+    return {"content": [{"type": "text", "text": text}]}
+
+
+def _json_result(obj) -> dict:
+    return _text_result(json.dumps(obj, indent=2, ensure_ascii=False))
+
+
+# ─── tool implementations ───────────────────────────────────────────
+
+def tool_tag_read(args: dict) -> dict:
+    path = args["path"]
+    return _json_result(gh_tag.read(path))
+
+
+def tool_tag_write(args: dict) -> dict:
+    return _json_result(gh_tag.write(
+        path=args["path"],
+        value=args["value"],
+        type=args.get("type", "String"),
+        quality=args.get("quality", "good"),
+        description=args.get("description", "written via acg-mcp"),
+    ))
+
+
+def tool_list_tags(args: dict) -> dict:
+    out, page = [], 1
+    while True:
+        rsp = gh_tag._req("GET", f"/repos/{gh_tag.REPO}/issues?labels=tag&state=open&per_page=100&page={page}")
+        if not isinstance(rsp, list) or not rsp:
+            break
+        for issue in rsp:
+            title = issue.get("title") or ""
+            if title.startswith("tag:"):
+                out.append({"path": title[4:], "issue": issue.get("number")})
+        if len(rsp) < 100:
+            break
+        page += 1
+    return _json_result({"count": len(out), "tags": sorted(out, key=lambda x: x["path"])})
+
+
+def tool_fire_event(args: dict) -> dict:
+    from state_machine import fire_event
+    return _json_result(fire_event(
+        tag=args["tag"],
+        from_state=args.get("from_state", "*"),
+        to_state=args.get("to_state", "CHANGED"),
+        kind=args.get("kind", "on_transition"),
+    ))
+
+
+def tool_list_scripts(args: dict) -> dict:
+    from state_machine import load_scripts
+    scripts = load_scripts()
+    tag = args.get("tag")
+    if tag:
+        scripts = [s for s in scripts if (s.get("trigger") or {}).get("tag") == tag]
+    slim = [{
+        "id":         s.get("id"),
+        "source":     s.get("_source"),
+        "script":     s.get("_script_file"),
+        "kind":       (s.get("trigger") or {}).get("kind"),
+        "tag":        (s.get("trigger") or {}).get("tag"),
+        "from":       (s.get("trigger") or {}).get("from"),
+        "to":         (s.get("trigger") or {}).get("to"),
+        "tool_id":    (s.get("action")  or {}).get("tool_id"),
+    } for s in scripts]
+    return _json_result({"count": len(slim), "scripts": slim})
+
+
+def tool_list_actions(args: dict) -> dict:
+    actions_dir = REPO / "guild" / "apps" / "control-deck" / "actions"
+    out = []
+    try:
+        manifest = json.loads((actions_dir / "index.json").read_text(encoding="utf-8"))
+    except Exception:
+        return _json_result({"error": "no action manifest"})
+    for fn in manifest.get("actions", []):
+        try:
+            doc = json.loads((actions_dir / fn).read_text(encoding="utf-8"))
+            p = doc.get("parameters", {})
+            out.append({
+                "id":     p.get("id") or Path(fn).stem,
+                "label":  p.get("label"),
+                "title":  p.get("title"),
+                "body":   (p.get("body") or "")[:200],
+            })
+        except Exception:
+            continue
+    return _json_result({"count": len(out), "actions": out})
+
+
+def tool_cmd_action(args: dict) -> dict:
+    actions_dir = REPO / "guild" / "apps" / "control-deck" / "actions"
+    aid = args["id"]
+    try:
+        doc = json.loads((actions_dir / f"{aid}.json").read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return _json_result({"ok": False, "error": f"unknown action {aid!r}"})
+    p = doc.get("parameters", {})
+    title = p.get("title") or f"cmd:{aid}"
+    body  = p.get("body")  or ""
+    tok = gh_tag._token()
+    if not tok:
+        return _json_result({
+            "ok": False,
+            "reason": "no PAT / gh auth — cannot POST an issue",
+            "title": title, "body": body,
+            "hint": f"set GITHUB_TOKEN or run `gh auth login`",
+        })
+    rsp = gh_tag._req("POST", f"/repos/{gh_tag.REPO}/issues",
+                      {"title": title, "body": body, "labels": ["cmd"]})
+    return _json_result({"ok": True, "issue": rsp.get("number"), "title": title})
+
+
+def tool_site_base(args: dict) -> dict:
+    return _text_result(_base())
+
+
+def tool_peek_api(args: dict) -> dict:
+    import urllib.request
+    url = args.get("url") or f"{_base()}/guild/Enterprise/L4/api/health.json"
+    try:
+        with urllib.request.urlopen(url, timeout=8) as r:
+            body = r.read().decode("utf-8", errors="replace")
+        try:
+            return _json_result({"url": url, "status": 200, "body": json.loads(body)})
+        except json.JSONDecodeError:
+            return _json_result({"url": url, "status": 200, "body_text": body[:4096]})
+    except Exception as e:
+        return _json_result({"url": url, "error": str(e)})
+
+
+# ─── tool registry + schemas ────────────────────────────────────────
+
+TOOLS = [
+    {
+        "name": "tag_read",
+        "description": "Read a tag from the GitHub-Issues-backed ACG tag DB.",
+        "inputSchema": {"type": "object", "required": ["path"],
+            "properties": {"path": {"type": "string", "description": "tag path, e.g. demo.heartbeat"}}},
+        "fn": tool_tag_read,
+    },
+    {
+        "name": "tag_write",
+        "description": "Upsert a tag value. Requires GITHUB_TOKEN.",
+        "inputSchema": {"type": "object", "required": ["path", "value"],
+            "properties": {
+                "path":        {"type": "string"},
+                "value":       {},
+                "type":        {"type": "string", "enum": ["String","Counter","Number","Boolean","DateTime","JSON"]},
+                "quality":     {"type": "string", "enum": ["good","uncertain","bad","stale"]},
+                "description": {"type": "string"},
+            }},
+        "fn": tool_tag_write,
+    },
+    {
+        "name": "list_tags",
+        "description": "List every open tag:* issue in the repo.",
+        "inputSchema": {"type": "object", "properties": {}},
+        "fn": tool_list_tags,
+    },
+    {
+        "name": "fire_event",
+        "description": "Inject a state-machine event. Returns matched + executed scripts.",
+        "inputSchema": {"type": "object", "required": ["tag"],
+            "properties": {
+                "tag":        {"type": "string"},
+                "from_state": {"type": "string", "default": "*"},
+                "to_state":   {"type": "string", "default": "CHANGED"},
+                "kind":       {"type": "string", "default": "on_transition"},
+            }},
+        "fn": tool_fire_event,
+    },
+    {
+        "name": "list_scripts",
+        "description": "List every StateMachineScript / Script UDT in the runner, optionally filtered by listens_tag.",
+        "inputSchema": {"type": "object", "properties": {"tag": {"type": "string"}}},
+        "fn": tool_list_scripts,
+    },
+    {
+        "name": "list_actions",
+        "description": "List the control-deck action catalogue.",
+        "inputSchema": {"type": "object", "properties": {}},
+        "fn": tool_list_actions,
+    },
+    {
+        "name": "cmd_action",
+        "description": "Invoke a control-deck action by id (files a cmd:<id> issue the cmd workflow handles).",
+        "inputSchema": {"type": "object", "required": ["id"],
+            "properties": {"id": {"type": "string", "description": "e.g. bump-heartbeat / rebuild-svgs"}}},
+        "fn": tool_cmd_action,
+    },
+    {
+        "name": "site_base",
+        "description": "Return the public Pages URL for whichever repo the code is hosted from.",
+        "inputSchema": {"type": "object", "properties": {}},
+        "fn": tool_site_base,
+    },
+    {
+        "name": "peek_api",
+        "description": "GET a public L4 API endpoint and return the JSON body (default: /api/health.json).",
+        "inputSchema": {"type": "object", "properties": {"url": {"type": "string"}}},
+        "fn": tool_peek_api,
+    },
+]
+
+TOOL_INDEX = {t["name"]: t for t in TOOLS}
+
+
+# ─── JSON-RPC framing ───────────────────────────────────────────────
+
+def _reply(id_, result=None, error=None):
+    msg = {"jsonrpc": "2.0", "id": id_}
+    if error is not None:
+        msg["error"] = error
+    else:
+        msg["result"] = result
+    sys.stdout.write(json.dumps(msg, ensure_ascii=False) + "\n")
+    sys.stdout.flush()
+
+
+def _notify(method, params=None):
+    msg = {"jsonrpc": "2.0", "method": method}
+    if params is not None:
+        msg["params"] = params
+    sys.stdout.write(json.dumps(msg, ensure_ascii=False) + "\n")
+    sys.stdout.flush()
+
+
+def handle(req: dict) -> None:
+    method = req.get("method")
+    id_    = req.get("id")
+    params = req.get("params") or {}
+
+    if method == "initialize":
+        _reply(id_, {
+            "protocolVersion": PROTOCOL_VERSION,
+            "serverInfo":      {"name": SERVER_NAME, "version": SERVER_VERSION},
+            "capabilities":    {"tools": {"listChanged": False}},
+        })
+        return
+
+    if method in ("notifications/initialized", "initialized"):
+        return  # no response expected
+
+    if method == "tools/list":
+        _reply(id_, {
+            "tools": [
+                {"name": t["name"], "description": t["description"], "inputSchema": t["inputSchema"]}
+                for t in TOOLS
+            ],
+        })
+        return
+
+    if method == "tools/call":
+        name = params.get("name")
+        args = params.get("arguments") or {}
+        tool = TOOL_INDEX.get(name)
+        if not tool:
+            _reply(id_, None, {"code": -32601, "message": f"unknown tool {name!r}"})
+            return
+        try:
+            _reply(id_, tool["fn"](args))
+        except Exception as e:
+            _reply(id_, {
+                "content": [{"type": "text", "text": f"tool error: {type(e).__name__}: {e}\n{traceback.format_exc()}"}],
+                "isError": True,
+            })
+        return
+
+    if method == "ping":
+        _reply(id_, {})
+        return
+
+    if id_ is not None:
+        _reply(id_, None, {"code": -32601, "message": f"method not found: {method}"})
+
+
+def main() -> int:
+    # Keep stderr for diagnostics, stdout reserved for JSON-RPC only.
+    print(f"[acg-mcp] ready  repo={gh_tag.REPO}  pid={os.getpid()}  tools={len(TOOLS)}", file=sys.stderr)
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            req = json.loads(line)
+        except Exception as e:
+            print(f"[acg-mcp] parse err: {e}  line={line[:120]!r}", file=sys.stderr)
+            continue
+        try:
+            handle(req)
+        except Exception as e:
+            print(f"[acg-mcp] handler crashed: {e}\n{traceback.format_exc()}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/acg-mqtt.py
+++ b/bin/acg-mqtt.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+acg-mqtt — headless MQTT-ish tag watcher. Polls the GH-Issues tag DB
+via gh_tag and fires a callback on value change. The durable side of
+the browser pub/sub at guild/Enterprise/L2/mqtt/.
+
+This is not a full broker — the browser is the live bus, this is the
+bridge from the GH-Issues-backed retained store.
+
+Usage
+-----
+  python bin/acg-mqtt.py sub demo.heartbeat
+      Print every change to tag:demo.heartbeat (polls every 10 s).
+
+  python bin/acg-mqtt.py sub "api.health.*"
+      Poll a set of tags. * wildcards work on the client side, so we
+      list-pull the matching issues and diff each one.
+
+  python bin/acg-mqtt.py pub demo.hello "world"
+      Publish a tag value (gh_tag.write).
+
+  python bin/acg-mqtt.py pub demo.counter 5 --type Counter
+
+Requires GITHUB_TOKEN / `gh auth token` for pub; reads are public.
+"""
+import argparse, fnmatch, json, re, sys, time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "guild" / "Enterprise" / "L2" / "lib"))
+import gh_tag  # noqa: E402
+
+DEFAULT_INTERVAL = 10
+
+
+def _list_tag_titles() -> list:
+    """Walk label:tag issues and return their path portions."""
+    out = []
+    for state in ("open", "closed"):
+        page = 1
+        while True:
+            rsp = gh_tag._req("GET", f"/repos/{gh_tag.REPO}/issues?labels=tag&state={state}&per_page=100&page={page}")
+            if not rsp:
+                break
+            for issue in rsp if isinstance(rsp, list) else []:
+                title = issue.get("title") or ""
+                if title.startswith("tag:"):
+                    out.append(title[4:])
+            if not isinstance(rsp, list) or len(rsp) < 100:
+                break
+            page += 1
+    return sorted(set(out))
+
+
+def _match(pattern: str, path: str) -> bool:
+    # Convert MQTT-style wildcards to fnmatch: * -> one segment, # -> rest
+    if "#" in pattern:
+        prefix = pattern.split("#", 1)[0].rstrip(".")
+        return path == prefix or path.startswith(prefix + ".")
+    # Single-segment * → fnmatch * is multi-segment, so translate to regex
+    if "*" in pattern:
+        re_p = re.escape(pattern).replace("\\*", "[^.]+")
+        return re.fullmatch(re_p, path) is not None
+    return pattern == path
+
+
+def cmd_sub(args) -> int:
+    seen = {}
+    interval = max(2, args.interval)
+    print(f"[acg-mqtt] sub {args.pattern!r}  interval={interval}s  repo={gh_tag.REPO}")
+    while True:
+        if "*" in args.pattern or "#" in args.pattern:
+            paths = [p for p in _list_tag_titles() if _match(args.pattern, p)]
+        else:
+            paths = [args.pattern]
+        for p in paths:
+            v = gh_tag.read(p)
+            if not v.get("ok"):
+                continue
+            ts = v.get("updated_at") or ""
+            key = f"{p}:{v.get('value')}:{ts}"
+            if seen.get(p) != key:
+                seen[p] = key
+                out = {
+                    "topic":    p,
+                    "msg":      v.get("value"),
+                    "quality":  v.get("quality"),
+                    "ts":       ts,
+                    "retained": True,
+                }
+                print(json.dumps(out, ensure_ascii=False))
+                sys.stdout.flush()
+        if args.once:
+            return 0
+        time.sleep(interval)
+
+
+def cmd_pub(args) -> int:
+    out = gh_tag.write(
+        path=args.topic,
+        value=args.value,
+        quality=args.quality,
+        type=args.type,
+        description=args.description or f"acg-mqtt pub at {int(time.time())}",
+    )
+    print(json.dumps(out, indent=2, ensure_ascii=False))
+    return 0 if out.get("ok") else 1
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    sp = ap.add_subparsers(dest="cmd", required=True)
+
+    s = sp.add_parser("sub", help="subscribe to a tag pattern")
+    s.add_argument("pattern")
+    s.add_argument("--interval", type=int, default=DEFAULT_INTERVAL)
+    s.add_argument("--once", action="store_true", help="emit current values then exit")
+    s.set_defaults(fn=cmd_sub)
+
+    p = sp.add_parser("pub", help="publish a tag value")
+    p.add_argument("topic")
+    p.add_argument("value")
+    p.add_argument("--quality",     default="good")
+    p.add_argument("--type",        default="String")
+    p.add_argument("--description", default="")
+    p.set_defaults(fn=cmd_pub)
+
+    args = ap.parse_args()
+    return args.fn(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/engineering/acg-mcp.md
+++ b/docs/engineering/acg-mcp.md
@@ -1,0 +1,104 @@
+# acg-mcp · Model Context Protocol server for the ACG control plane
+
+`bin/acg-mcp.py` is a zero-dep (stdlib-only) MCP server that exposes
+the GH-Issues tag DB, state-machine runner, and control-deck action
+catalogue through the standard MCP tool schema. Any MCP-capable
+client (Claude Desktop, Claude Code, the `mcp` CLI, custom agents) can
+read/write tags, fire state-machine events, and invoke `cmd:*`
+actions — the same things the README buttons do — through typed tool
+calls.
+
+## Transport
+
+Standard MCP stdio transport: newline-delimited JSON-RPC 2.0 over
+stdin/stdout. `stderr` is reserved for human-readable diagnostics.
+utf-8 is forced on startup so Windows consoles don't drop emoji.
+
+## Tools
+
+| tool           | purpose                                                       |
+|----------------|---------------------------------------------------------------|
+| `tag_read`     | Read a tag from the GH-Issues tag DB                          |
+| `tag_write`    | Upsert a tag value (requires `GITHUB_TOKEN`)                  |
+| `list_tags`    | Enumerate every open `tag:*` issue                            |
+| `fire_event`   | Inject a state-machine event, get matched + executed scripts  |
+| `list_scripts` | Every StateMachineScript / Script UDT, optionally filtered    |
+| `list_actions` | The control-deck action catalogue                             |
+| `cmd_action`   | Invoke a cmd action by id (files a `cmd:<id>` issue)          |
+| `site_base`    | The public Pages URL for the current repo                     |
+| `peek_api`     | GET a public L4 API endpoint                                  |
+
+Every tool returns `{content: [{type:"text", text:"<json>"}]}` per
+MCP conventions.
+
+## Install · Claude Desktop
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json`
+(macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "acg": {
+      "command": "python",
+      "args": ["<ABSOLUTE-PATH>/bin/acg-mcp.py"],
+      "env": { "GITHUB_TOKEN": "ghp_..." }
+    }
+  }
+}
+```
+
+Restart Claude Desktop. You should see `acg` in the 🔌 tools list.
+
+## Install · Claude Code
+
+```
+claude mcp add acg -- python "<ABSOLUTE-PATH>/bin/acg-mcp.py"
+# then set the token as an env var or add it to the .mcp.json entry
+```
+
+## Install · stdio from any agent
+
+Launch the process with the working dir set to the repo root. The
+server reads one JSON request per line and writes one JSON response
+per line.
+
+```
+python bin/acg-mcp.py
+```
+
+## Example session
+
+Drive the server manually with `printf | python`:
+
+```bash
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","clientInfo":{"name":"test","version":"0"}}}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"tag_read","arguments":{"path":"demo.heartbeat"}}}' \
+  | python bin/acg-mcp.py
+```
+
+Reply (abbreviated):
+
+```json
+{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","serverInfo":{"name":"acg","version":"0.1.0"},"capabilities":{"tools":{"listChanged":false}}}}
+{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"{\"ok\":true,\"path\":\"demo.heartbeat\",\"value\":1776509355,...}"}]}}
+```
+
+## Relationship to the rest of the stack
+
+| MCP call         | What it really does                                                   |
+|------------------|-----------------------------------------------------------------------|
+| `tag_read`       | `gh_tag.read(path)` — HTTP GET on `/repos/<org>/issues?labels=tag`    |
+| `tag_write`      | `gh_tag.write(...)` — POST/PATCH issue + comment (needs token)        |
+| `fire_event`     | `state_machine.fire_event(...)` — runs each matched Tool UDT          |
+| `list_scripts`   | `state_machine.load_scripts()`                                        |
+| `list_actions`   | reads `guild/apps/control-deck/actions/*.json`                        |
+| `cmd_action`     | POSTs a `cmd:*` issue; the `cmd` workflow runs the matching action   |
+
+## Security
+
+- All writes require `GITHUB_TOKEN` (or `gh auth token`). Without one,
+  `tag_write` and `cmd_action` return `{ok:false, reason:"no PAT"}`.
+- The server never prints the token.
+- Reads are anonymous and rate-limited to 60 req/hr per IP by GitHub.

--- a/guild/Enterprise/L2/mqtt/README.md
+++ b/guild/Enterprise/L2/mqtt/README.md
@@ -1,0 +1,89 @@
+# ACG MQTT · topic pub/sub over the WebRTC mesh
+
+Single-file, zero-dep pub/sub for the browser, with MQTT-shaped
+semantics (topics, wildcards, retained) on top of the existing ACG
+mesh. One shared vocabulary across tags, script events, and peer
+traffic — a topic path is a tag path is a script trigger.
+
+## API
+
+```js
+import mqtt, { subscribe, publish, matchTopic, peek, attachMesh }
+  from './mqtt.js';
+
+// local-only pub/sub
+const unsub = subscribe('peer.*.state', (topic, msg, rec) => {
+  console.log(topic, msg, rec.from, rec.retained);
+});
+publish('peer.abc.state', 'connected');
+
+// retained: new subscribers of the same topic get this immediately
+publish('room.name', 'acg-whiteboard', { retained: true });
+
+// mesh attach: publishes also reach other peers in the current room
+import * as p2p from '../scada/gateway/scripts/p2p.js';
+import * as peers from '../scada/gateway/scripts/peers.js';
+import { myId } from '../scada/gateway/scripts/config.js';
+attachMesh({ bcast: p2p.bcast, registerPeerHandler: peers.registerPeerHandler, myId });
+```
+
+## Wildcards
+
+| pattern      | matches                         | not                       |
+|--------------|---------------------------------|---------------------------|
+| `peer.*.state`      | `peer.abc.state`         | `peer.state`, `peer.a.b.state` |
+| `peer.#`            | `peer.abc`, `peer.abc.state`, `peer.abc.dc.open` | `peer` |
+| `#`                 | anything                 | (nothing)                 |
+
+`*` matches exactly one segment, `#` matches the rest of the path.
+
+## Retained messages
+
+`publish(topic, msg, { retained: true })` stores the message. Any new
+`subscribe(topic)` whose pattern matches gets the retained value
+replayed immediately — same as MQTT retained topics.
+
+`peek(topic)` returns the last retained record or `null`. Useful for
+"what's the current value" without subscribing.
+
+## Mesh transport
+
+When `attachMesh` is called, every non-local publish also fans out
+over the WebRTC data channel `bcast` as `{t:'mqtt', rec}`. Remote
+peers with the mesh handler wired call back into `publish(…,
+{_fromPeer:true})` so their local subscribers fire. No loopback — a
+peer that receives an MQTT envelope does not re-broadcast.
+
+## Topic catalogue
+
+See `docs/engineering/connection-events.md` for the current vocabulary
+(tracker.*, signal.*, peer.*, room.*, api.*, packml.*, pipeline.*).
+Every `@tag-event` header in the repo is effectively a subscription on
+one of those topics.
+
+## Live demo
+
+Open `guild/Enterprise/L2/mqtt/` in a browser. The page:
+- auto-attaches to the mesh and joins room `mqtt-bus`
+- defaults to subscribing `#` (everything)
+- lets you add more patterns, publish, toggle retained
+- runs 5 self-tests on load (visible in the footer strip)
+
+Open two tabs in the same room to watch cross-peer publishes land.
+
+## Python counterpart · `bin/acg-mqtt.py`
+
+Headless subscriber that polls the GitHub-Issues tag DB and fires a
+callback on change. Not a real MQTT broker — it's the durable-tag
+side of the pair. The browser is the live side.
+
+## Relationship to existing concepts
+
+- **tag path == topic**
+- **script `@tag-event` == subscription**
+- **retained == GH-Issues backed tag value**
+- **publish with `local:true` == local bus only, no peer fanout**
+
+An MQTT-subscriber script could live in `L3/udts/script/` with a
+trigger like `{kind:"on_publish", topic:"peer.*.state"}` once the
+matcher learns `*` wildcards — that upgrade is queued for the next PR.

--- a/guild/Enterprise/L2/mqtt/index.html
+++ b/guild/Enterprise/L2/mqtt/index.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>📡 ACG MQTT · live bus</title>
+<link rel="stylesheet" href="../scada/gateway/styles/theme.css">
+<style>
+  html,body{height:100vh;margin:0;overflow:hidden;display:flex;flex-direction:column;background:var(--bg);color:var(--tx);font-family:var(--ff-body);font-size:12px}
+  header{flex:0 0 auto;display:flex;align-items:center;gap:12px;padding:10px 14px;background:var(--card);border-bottom:1px solid var(--bd);flex-wrap:wrap}
+  header h1{font-family:var(--ff-display);font-size:15px;margin:0;font-weight:600}
+  header h1 small{color:var(--dm);font-weight:400;margin-left:8px;font-size:10px}
+  header .spacer{flex:1}
+  header a{color:var(--tl);text-decoration:none;font-size:11px;padding:3px 10px;border-radius:4px;border:1px solid transparent}
+  header a:hover{background:var(--tlb);border-color:var(--tl)}
+  .stats{font-family:var(--ff-mono);font-size:10px;color:var(--dm);padding:2px 10px;background:var(--inp);border:1px solid var(--bd);border-radius:12px}
+  .stats b{color:var(--tx)}
+  main{flex:1;display:grid;grid-template-columns:340px 1fr;gap:0;overflow:hidden}
+  .left{border-right:1px solid var(--bd);display:flex;flex-direction:column;overflow:hidden}
+  .sect{padding:10px 14px;border-bottom:1px solid var(--bd)}
+  .sect h2{font-size:10px;margin:0 0 6px;color:var(--tl);text-transform:uppercase;letter-spacing:1.6px;font-weight:700}
+  .row{display:flex;gap:6px;margin-bottom:6px}
+  input,select,button,textarea{background:var(--inp);color:var(--tx);border:1px solid var(--bd);border-radius:4px;padding:5px 8px;font-family:var(--ff-mono);font-size:11px}
+  button{cursor:pointer;font-family:var(--ff-body);font-weight:600}
+  button:hover{border-color:var(--tl);color:var(--tl)}
+  button.primary{background:var(--tl);border-color:var(--tl);color:#fff}
+  .subs{font-family:var(--ff-mono);font-size:10px;padding:4px 0;flex:1;overflow:auto}
+  .subs .item{display:flex;justify-content:space-between;padding:3px 14px;border-bottom:1px solid var(--bd2)}
+  .subs .item code{color:var(--tl)}
+  .subs .item .unsub{cursor:pointer;color:var(--dm)}
+  .subs .item .unsub:hover{color:var(--rs)}
+  .bus{overflow:auto;padding:4px 0;font-family:var(--ff-mono);font-size:11px;background:#0b1018}
+  .bus .msg{padding:3px 14px;border-bottom:1px solid #1a2030;display:grid;grid-template-columns:80px 1fr auto;gap:10px;align-items:baseline}
+  .bus .msg .t{color:var(--dm);font-size:10px}
+  .bus .msg .k{color:var(--tl);font-weight:700}
+  .bus .msg .v{color:var(--tx);word-break:break-all}
+  .bus .msg .meta{color:var(--ft);font-size:9px}
+  .bus .msg.retained .k::after{content:' (retained)';color:var(--amb);font-size:9px;font-weight:400}
+  .bus .msg.from-peer .k::before{content:'← ';color:var(--sg)}
+  #tests{padding:10px 14px;background:var(--card);border-top:1px solid var(--bd);font-family:var(--ff-mono);font-size:10px;max-height:160px;overflow:auto}
+  #tests .ok{color:var(--sg)} #tests .fail{color:var(--rs)}
+</style>
+</head>
+<body>
+<header>
+  <h1>📡 ACG MQTT<small>· topic bus over WebRTC mesh</small></h1>
+  <span class="spacer"></span>
+  <span class="stats" id="stats">0 subs · 0 retained · mesh=no</span>
+  <a href="../../../apps/whiteboard/">🖍 whiteboard</a>
+  <a href="../../../apps/control-deck/">⚒ deck</a>
+  <a href="../../../../index.html">⚒ guild</a>
+</header>
+
+<main>
+  <div class="left">
+    <div class="sect">
+      <h2>subscribe</h2>
+      <div class="row">
+        <input id="sub-topic" placeholder="topic pattern (e.g. peer.*.state)" style="flex:1" value="#">
+        <button id="sub-btn">add</button>
+      </div>
+      <div class="hint" style="color:var(--dm);font-size:10px;margin-top:4px">wildcards: <code>*</code> = one segment, <code>#</code> = rest of path</div>
+    </div>
+
+    <div class="sect">
+      <h2>publish</h2>
+      <div class="row">
+        <input id="pub-topic" placeholder="topic" style="flex:1" value="demo.hello">
+      </div>
+      <div class="row">
+        <input id="pub-msg" placeholder="message (string or JSON)" style="flex:1" value="from-the-mqtt-demo">
+      </div>
+      <div class="row">
+        <label style="color:var(--dm);font-size:10px"><input type="checkbox" id="pub-retained"> retained</label>
+        <span class="spacer" style="flex:1"></span>
+        <button id="pub-btn" class="primary">publish</button>
+      </div>
+    </div>
+
+    <div class="sect" style="flex:1;overflow:auto">
+      <h2>active subscriptions</h2>
+      <div class="subs" id="subs"></div>
+    </div>
+  </div>
+
+  <div class="bus" id="bus"></div>
+</main>
+
+<div id="tests">loading self-tests…</div>
+
+<script type="module">
+import mqtt, { subscribe, publish, matchTopic, peek, listSubscriptions, stats, attachMesh, clearRetained } from './mqtt.js';
+
+// ── attach to the mesh if it's available (lets peers see our publishes)
+try {
+  const p2p   = await import('../scada/gateway/scripts/p2p.js');
+  const peers = await import('../scada/gateway/scripts/peers.js');
+  const cfg   = await import('../scada/gateway/scripts/config.js');
+  attachMesh({ bcast: p2p.bcast, registerPeerHandler: peers.registerPeerHandler, myId: cfg.myId });
+  // Auto-join a "mqtt-bus" room so visitors across tabs all see each other.
+  setTimeout(() => p2p.join('mqtt-bus'), 400);
+} catch (e) { console.warn('mesh not attached:', e.message); }
+
+// ── ui
+const $ = id => document.getElementById(id);
+const busEl = $('bus');
+const subsEl = $('subs');
+const statsEl = $('stats');
+const activeSubs = new Map(); // id -> {pattern, unsub}
+
+function renderStats() {
+  const s = stats();
+  statsEl.innerHTML = `<b>${s.subs}</b> subs · <b>${s.retained}</b> retained · mesh=<b>${s.connectedToMesh ? 'yes' : 'no'}</b>`;
+}
+
+function renderSubs() {
+  subsEl.innerHTML = '';
+  for (const [id, info] of activeSubs) {
+    const row = document.createElement('div');
+    row.className = 'item';
+    row.innerHTML = `<span><code>${esc(info.pattern)}</code></span><span class="unsub" data-id="${id}">×</span>`;
+    subsEl.appendChild(row);
+  }
+  renderStats();
+}
+
+subsEl.addEventListener('click', e => {
+  const id = Number(e.target.dataset.id);
+  if (!id) return;
+  const info = activeSubs.get(id);
+  if (info) { info.unsub(); activeSubs.delete(id); renderSubs(); }
+});
+
+function esc(s) { return String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;'); }
+function hhmmss() { return new Date().toTimeString().slice(0,8); }
+
+function appendToBus(topic, msg, rec) {
+  const el = document.createElement('div');
+  el.className = 'msg' + (rec.retained ? ' retained' : '') + (rec.from && rec.from !== stats().myId ? ' from-peer' : '');
+  const body = typeof msg === 'string' ? msg : JSON.stringify(msg);
+  el.innerHTML = `<span class="t">${hhmmss()}</span><span><span class="k">${esc(topic)}</span> <span class="v">${esc(body).slice(0, 200)}</span></span><span class="meta">${esc(rec.from || '')}</span>`;
+  busEl.appendChild(el);
+  busEl.scrollTop = busEl.scrollHeight;
+  while (busEl.children.length > 400) busEl.removeChild(busEl.firstChild);
+}
+
+function addSub(pattern) {
+  if (!pattern) return;
+  const unsub = subscribe(pattern, appendToBus);
+  const id = listSubscriptions().slice(-1)[0].id;
+  activeSubs.set(id, { pattern, unsub });
+  renderSubs();
+}
+
+$('sub-btn').addEventListener('click', () => {
+  const p = $('sub-topic').value.trim();
+  if (p) addSub(p);
+});
+$('sub-topic').addEventListener('keydown', e => { if (e.key === 'Enter') $('sub-btn').click(); });
+
+$('pub-btn').addEventListener('click', () => {
+  const topic = $('pub-topic').value.trim();
+  if (!topic) return;
+  let msg = $('pub-msg').value;
+  try { msg = JSON.parse(msg); } catch {}
+  publish(topic, msg, { retained: $('pub-retained').checked });
+});
+$('pub-msg').addEventListener('keydown', e => { if (e.key === 'Enter') $('pub-btn').click(); });
+
+// default sub: everything
+addSub('#');
+
+// ── self-tests (run once on load)
+const testsEl = $('tests');
+testsEl.innerHTML = '';
+function t(name, ok, note='') {
+  const line = document.createElement('div');
+  line.className = ok ? 'ok' : 'fail';
+  line.textContent = (ok ? '[ok]   ' : '[FAIL] ') + name + (note ? '  — ' + note : '');
+  testsEl.appendChild(line);
+  return ok;
+}
+
+{
+  let hits = 0;
+  const unsub = subscribe('test.*.value', () => { hits++; });
+  publish('test.a.value', 1, { local: true });
+  publish('test.b.value', 2, { local: true });
+  publish('test.a.other', 3, { local: true });
+  t('wildcard * matches one segment', hits === 2, 'expected 2 hits, got ' + hits);
+  unsub();
+}
+{
+  let hits = 0;
+  const unsub = subscribe('tree.#', () => { hits++; });
+  publish('tree.a',      1, { local: true });
+  publish('tree.a.b',    2, { local: true });
+  publish('tree.a.b.c',  3, { local: true });
+  publish('other.tree.a', 4, { local: true });
+  t('# matches rest of path', hits === 3, 'expected 3 hits, got ' + hits);
+  unsub();
+}
+{
+  publish('retained.value', 42, { retained: true, local: true });
+  let hits = 0;
+  const unsub = subscribe('retained.value', (topic, msg) => { if (msg === 42) hits++; });
+  t('retained replayed to new sub', hits === 1);
+  unsub();
+  clearRetained('retained.value');
+}
+{
+  t('matchTopic function', matchTopic('a.*.c', 'a.b.c') && !matchTopic('a.*.c', 'a.b.d.c'));
+}
+{
+  t('peek returns last retained', (publish('peek.t', 'x', { retained: true, local: true }), peek('peek.t').msg === 'x'));
+  clearRetained('peek.t');
+}
+renderStats();
+
+// expose for console poking
+window.mqtt = mqtt;
+window.m = { publish, subscribe, stats, peek, listSubscriptions };
+</script>
+
+</body>
+</html>

--- a/guild/Enterprise/L2/mqtt/mqtt.js
+++ b/guild/Enterprise/L2/mqtt/mqtt.js
@@ -1,0 +1,127 @@
+// ═══ ACG MQTT-shaped pub/sub ═════════════════════════════════════════
+// Topic-based pub/sub that mirrors MQTT semantics but uses the existing
+// ACG mesh as transport. Topics == tag paths ("peer.abc.state",
+// "tracker.current.state", "room.peerCount"). One message type per
+// publish: {topic, msg, retained?, ts, from}.
+//
+// Wildcards:
+//   *   matches exactly one segment  (peer.*.state)
+//   #   matches the rest of the path (peer.#  /  #)
+//
+// Transport:
+//   Local subscribers always fire synchronously.
+//   If p2p is available and `bcast()` is importable, publishes with
+//   `local:false` (default) also propagate to every connected peer.
+//   Peers with `registerPeerHandler('mqtt', ...)` wired call back into
+//   here and fire local subscribers on their side.
+//
+// No external broker, no websocket server. A single file, zero deps.
+
+const subs = [];           // [{pattern, re, fn, id}]
+const retained = new Map();// topic -> last message {topic,msg,ts,retained:true}
+let nextSubId = 1;
+
+let bcastFn  = null;       // optional: p2p bcast(str)
+let myId     = 'local';    // optional: local peer id
+let peerRecv = null;       // optional: unregister fn
+
+// ── topic pattern matching ───────────────────────────────────────────
+function patternToRegex(pattern) {
+  // Escape regex chars EXCEPT our wildcards, then substitute them.
+  const esc = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
+  const re  = esc.replace(/\*/g, '[^.]+').replace(/#/g, '.*');
+  return new RegExp('^' + re + '$');
+}
+
+export function matchTopic(pattern, topic) {
+  return patternToRegex(pattern).test(topic);
+}
+
+// ── local api ────────────────────────────────────────────────────────
+export function subscribe(pattern, fn, opts = {}) {
+  const id = nextSubId++;
+  const entry = { id, pattern, re: patternToRegex(pattern), fn };
+  subs.push(entry);
+  // Replay retained messages whose topic matches this new subscription.
+  if (opts.replayRetained !== false) {
+    for (const [topic, rec] of retained) {
+      if (entry.re.test(topic)) {
+        try { fn(topic, rec.msg, rec); } catch (e) { console.error('mqtt sub err', e); }
+      }
+    }
+  }
+  return () => unsubscribe(id);
+}
+
+export function unsubscribe(id) {
+  const i = subs.findIndex(s => s.id === id);
+  if (i >= 0) subs.splice(i, 1);
+}
+
+export function publish(topic, msg, opts = {}) {
+  const rec = {
+    topic,
+    msg,
+    ts:       Date.now(),
+    from:     opts.from || myId,
+    retained: !!opts.retained,
+    qos:      opts.qos || 0,
+  };
+  // Retained = remember last value, new subscribers get it immediately
+  if (rec.retained) retained.set(topic, rec);
+  // Fire local subscribers
+  for (const s of subs) {
+    if (s.re.test(topic)) {
+      try { s.fn(topic, msg, rec); } catch (e) { console.error('mqtt sub err', e); }
+    }
+  }
+  // Fan out to peers unless caller said local-only or this came from a peer
+  if (!opts.local && !opts._fromPeer && bcastFn) {
+    try { bcastFn(JSON.stringify({ t: 'mqtt', rec })); } catch (e) { /* mesh not ready */ }
+  }
+  return rec;
+}
+
+// ── convenience ──────────────────────────────────────────────────────
+export function peek(topic) {
+  return retained.get(topic) || null;
+}
+export function clearRetained(topic) {
+  if (topic) retained.delete(topic);
+  else retained.clear();
+}
+export function listSubscriptions() {
+  return subs.map(s => ({ id: s.id, pattern: s.pattern }));
+}
+export function stats() {
+  return {
+    subs:     subs.length,
+    retained: retained.size,
+    connectedToMesh: !!bcastFn,
+    myId,
+  };
+}
+
+// ── optional mesh integration ────────────────────────────────────────
+// Call once from your app after importing peers.js / p2p.js.
+export function attachMesh({ bcast, registerPeerHandler, myId: id } = {}) {
+  if (bcast) bcastFn = bcast;
+  if (id) myId = id;
+  if (registerPeerHandler) {
+    if (peerRecv) peerRecv();
+    registerPeerHandler('mqtt', (m /*, rid */) => {
+      if (!m || !m.rec) return;
+      // Re-publish locally only; do NOT fan out again.
+      publish(m.rec.topic, m.rec.msg, {
+        ...m.rec,
+        local:      true,
+        _fromPeer:  true,
+      });
+    });
+    peerRecv = () => {}; // placeholder — peers.js doesn't expose unregister
+  }
+}
+
+// ── default export for convenience ───────────────────────────────────
+export default { subscribe, unsubscribe, publish, peek, matchTopic,
+  clearRetained, listSubscriptions, stats, attachMesh };

--- a/guild/apps/control-deck/index.html
+++ b/guild/apps/control-deck/index.html
@@ -15,6 +15,7 @@
   <a href="../terminal/">⌨ terminal</a>
   <a href="../whiteboard/">🖍 whiteboard</a>
   <a href="../udt-editor/#udt=machine&instance=line-1">🗂 UDT editor</a>
+  <a href="../../Enterprise/L2/mqtt/">📡 mqtt</a>
   <a href="../../../index.html">⚒ guild</a>
 </header>
 


### PR DESCRIPTION
## Summary
Two new integration layers that share the existing tag/topic vocabulary.

### MQTT pub/sub (`guild/Enterprise/L2/mqtt/`)
- **`mqtt.js`** — single-file zero-dep pub/sub. Wildcards (`*` one segment, `#` rest), retained messages, optional `attachMesh()` that routes publishes across peers.
- **`index.html`** — live bus page. Default sub `#`, sub/pub forms, 5 self-tests run on load (all green), auto-joins room `mqtt-bus` so two tabs see each other.
- **`README.md`** — API + wildcard table + MQTT↔ACG semantic map.
- **`bin/acg-mqtt.py`** — headless bridge to the GH-Issues tag DB. `sub <pattern> --once` emits current values; `pub` wraps `gh_tag.write`.
- Control-deck header gains a 📡 mqtt link.

### MCP server (`bin/acg-mcp.py`)
Stdio JSON-RPC 2.0, MCP protocol version 2024-11-05, zero dependencies. Forces utf-8 on stdio so Windows consoles don't drop emoji.

Tools: `tag_read`, `tag_write`, `list_tags`, `fire_event`, `list_scripts`, `list_actions`, `cmd_action`, `site_base`, `peek_api`.

Drop into `claude_desktop_config.json`:
```json
{ "mcpServers": { "acg": { "command": "python", "args": ["<REPO>/bin/acg-mcp.py"], "env": {"GITHUB_TOKEN": "ghp_..."} } } }
```

See `docs/engineering/acg-mcp.md` for full install/usage.

## Local smoke tests
**MQTT**: 5/5 in-browser tests green. `acg-mqtt.py sub demo.heartbeat --once` → `{"topic":"demo.heartbeat","msg":1776509355,...}`.

**MCP**: drove `initialize → tools/list → tools/call` for `tag_read`, `list_actions`, `list_scripts`, `site_base` — structured JSON-RPC responses returned. tag_read pulled the live heartbeat counter. list_actions returned the 4-action catalogue with emoji labels preserved.

## Test plan
- [ ] `/guild/Enterprise/L2/mqtt/` — footer strip shows 5 green `[ok]` tests.
- [ ] Two whiteboard-mqtt tabs → publishes cross-forward.
- [ ] `python bin/acg-mqtt.py sub demo.heartbeat --once` prints current value.
- [ ] `python bin/acg-mcp.py` replies to an `initialize` request on stdin.
- [ ] Add the `acg` MCP server to a Claude Desktop config → `tag_read`/`list_actions` callable from chat.

## Relationship to other PRs
- **PR #24** (sm-tests + tracker probe) — independent; once merged, `list_scripts` via MCP returns 53 entries instead of 0.
- Matcher upgrade to natively accept `*`/`#` in `trigger.tag` is a queued follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)