### PR TITLE
refresh signatories loader: no-cache fetch and drop URL rows

### DIFF
--- a/index.html
+++ b/index.html
@@ -1119,17 +1119,28 @@
             const signatoriesCount = document.getElementById('signatoriesCount');
             
             try {
-                // For public sheets, you can use the published CSV URL
-                const csvUrl = `https://docs.google.com/spreadsheets/d/${CONFIG.SHEET_ID}/gviz/tq?tqx=out:csv&sheet=${encodeURIComponent(CONFIG.SHEET_NAME)}`;
-                
-                const response = await fetch(csvUrl);
+                // Append a cache-busting timestamp so edits to the sheet
+                // propagate immediately instead of being served from the
+                // gviz cache or the browser cache.
+                const csvUrl = `https://docs.google.com/spreadsheets/d/${CONFIG.SHEET_ID}/gviz/tq?tqx=out:csv&sheet=${encodeURIComponent(CONFIG.SHEET_NAME)}&_=${Date.now()}`;
+
+                const response = await fetch(csvUrl, { cache: 'no-store' });
                 const csvText = await response.text();
-                
+
                 // Parse CSV
                 const rows = parseCSV(csvText);
-                
-                // Skip header row and reverse to show newest first
-                const signatories = rows.slice(1).reverse();
+
+                // Skip header row, drop rows whose display fields contain a
+                // URL (paste artefacts, not real signatories), and reverse to
+                // show newest first.
+                const containsUrl = (text) =>
+                    /https?:\/\//i.test(text) ||
+                    /\b[a-z0-9-]+\.[a-z]{2,}\/[a-z0-9]/i.test(text);
+                const isValidRow = (row) => {
+                    const display = [row[1], row[2], row[3]].filter(Boolean).join(' ');
+                    return !containsUrl(display);
+                };
+                const signatories = rows.slice(1).filter(isValidRow).reverse();
                 
                 // Update count
                 signatoriesCount.textContent = `${signatories.length} ${signatories.length === 1 ? 'signatory' : 'signatories'}`;


### PR DESCRIPTION
## Summary

Two small changes to `loadSignatories()` in `index.html`:

- Append a timestamp query param to the sheet URL and pass `{cache: 'no-store'}` to `fetch`. The `gviz/tq` endpoint and the browser both cache aggressively; without this, edits to the sheet can take an hour or more to appear on the page.
- Drop rows whose name, title or organisation field contains a URL. Those fields are plain-text identity; URLs there are paste artefacts, not signatories.

No change for valid signatories.

## Test plan

- [ ] Merge and hard-reload `index.html`; confirm the signatory list matches the current state of the sheet.
- [ ] Edit a row in the sheet; on the next page load the change is visible (no need to wait for a cache TTL).
- [ ] A row with a URL in the name/title/org field does not render as a card.