### PR TITLE
bake signatories into repo data file (supersedes #29)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1082,13 +1082,6 @@
     <iframe name="hidden_iframe" id="hidden_iframe" style="display:none;"></iframe>
 
     <script>
-        // Configuration - UPDATE THESE VALUES
-        const CONFIG = {
-            SHEET_ID: '1WldGelJJZUkQc4-r9PaCwpNWcI9sc7Rtif_7XB7x7hc',  // Get this from the Sheet URL
-            SHEET_NAME: 'Form Responses 1',     // Usually this is the default name
-            API_KEY: 'YOUR_GOOGLE_API_KEY'      // Optional - for public sheets you may not need this
-        };
-
         // Handle form submission
         const form = document.getElementById('signatureForm');
         const submitBtn = document.getElementById('submitBtn');
@@ -1101,49 +1094,46 @@
             // Show success message after a delay (form submits to iframe)
             setTimeout(() => {
                 formStatus.className = 'form-status success';
-                formStatus.textContent = 'Thank you for signing the manifesto! Your signature will appear below shortly.';
+                formStatus.textContent = 'Thank you for signing the manifesto! Your signature will appear once reviewed.';
                 form.reset();
                 submitBtn.disabled = false;
                 submitBtn.textContent = 'Sign the Manifesto';
-                
-                // Reload signatures after 2 seconds
-                setTimeout(() => {
-                    loadSignatories();
-                }, 2000);
             }, 1000);
         });
 
-        // Function to load signatories from Google Sheets
+        // Load signatories from the repo data file.
         async function loadSignatories() {
             const signatoriesList = document.getElementById('signatoriesList');
             const signatoriesCount = document.getElementById('signatoriesCount');
-            
+
             try {
-                // For public sheets, you can use the published CSV URL
-                const csvUrl = `https://docs.google.com/spreadsheets/d/${CONFIG.SHEET_ID}/gviz/tq?tqx=out:csv&sheet=${encodeURIComponent(CONFIG.SHEET_NAME)}`;
-                
-                const response = await fetch(csvUrl);
-                const csvText = await response.text();
-                
-                // Parse CSV
-                const rows = parseCSV(csvText);
-                
-                // Skip header row and reverse to show newest first
-                const signatories = rows.slice(1).reverse();
-                
-                // Update count
+                // Cache-bust so edits to signatories.json propagate on next load.
+                const response = await fetch(`signatories.json?_=${Date.now()}`, { cache: 'no-store' });
+                const data = await response.json();
+
+                // Defence-in-depth: drop rows whose display fields contain a URL.
+                const containsUrl = (text) =>
+                    /https?:\/\//i.test(text) ||
+                    /\b[a-z0-9-]+\.[a-z]{2,}\/[a-z0-9]/i.test(text);
+                const isValid = (entry) => {
+                    if (!entry || !entry.name) return false;
+                    const display = [entry.name, entry.title, entry.org].filter(Boolean).join(' ');
+                    return !containsUrl(display);
+                };
+
+                // Show newest first.
+                const signatories = data.filter(isValid).slice().reverse();
+
                 signatoriesCount.textContent = `${signatories.length} ${signatories.length === 1 ? 'signatory' : 'signatories'}`;
-                
-                // Display signatories
+
                 if (signatories.length === 0) {
                     signatoriesList.innerHTML = '<div class="loading">Be the first to sign!</div>';
                 } else {
-                    signatoriesList.innerHTML = signatories.map(row => {
-                        // Assuming columns: Timestamp, Name, Title, Organization, Email
-                        const name = row[1] || 'Anonymous';
-                        const title = row[2] || '';
-                        const org = row[3] || '';
-                        
+                    signatoriesList.innerHTML = signatories.map(entry => {
+                        const name = entry.name || 'Anonymous';
+                        const title = entry.title || '';
+                        const org = entry.org || '';
+
                         return `
                             <div class="signatory-card">
                                 <div class="signatory-name">${escapeHtml(name)}</div>
@@ -1158,48 +1148,6 @@
                 signatoriesList.innerHTML = '<div class="loading">Unable to load signatories. Please check back later.</div>';
                 signatoriesCount.textContent = '';
             }
-        }
-
-        // Simple CSV parser
-        function parseCSV(csv) {
-            const rows = [];
-            let currentRow = [];
-            let currentField = '';
-            let inQuotes = false;
-            
-            for (let i = 0; i < csv.length; i++) {
-                const char = csv[i];
-                const nextChar = csv[i + 1];
-                
-                if (char === '"') {
-                    if (inQuotes && nextChar === '"') {
-                        currentField += '"';
-                        i++;
-                    } else {
-                        inQuotes = !inQuotes;
-                    }
-                } else if (char === ',' && !inQuotes) {
-                    currentRow.push(currentField);
-                    currentField = '';
-                } else if ((char === '\n' || char === '\r') && !inQuotes) {
-                    if (currentField || currentRow.length > 0) {
-                        currentRow.push(currentField);
-                        rows.push(currentRow);
-                        currentRow = [];
-                        currentField = '';
-                    }
-                    if (char === '\r' && nextChar === '\n') i++;
-                } else {
-                    currentField += char;
-                }
-            }
-            
-            if (currentField || currentRow.length > 0) {
-                currentRow.push(currentField);
-                rows.push(currentRow);
-            }
-            
-            return rows;
         }
 
         // Escape HTML to prevent XSS

--- a/signatories.json
+++ b/signatories.json
@@ -1,0 +1,344 @@
+[
+  {
+    "name": "Alex Bunardzic",
+    "title": "Business Velocity Architect",
+    "org": "Digital Exprt Ventures Inc.",
+    "signed_at": "2/3/2026 13:34:39"
+  },
+  {
+    "name": "Matt Burch",
+    "title": "Advisor & AI-First Engineer",
+    "org": "4thWAIV / Cascadia Logic",
+    "signed_at": "2/3/2026 15:31:08"
+  },
+  {
+    "name": "Alexander Thurow",
+    "title": "Software Development Culture Consultant",
+    "org": "onmoderndev.de",
+    "signed_at": "2/3/2026 15:49:30"
+  },
+  {
+    "name": "Thomas Frumkin",
+    "title": "CTHOMAS",
+    "org": "Konomi Systems",
+    "signed_at": "2/3/2026 20:31:13"
+  },
+  {
+    "name": " Bart Swierstra",
+    "title": "Lead scrum master",
+    "org": "Optional",
+    "signed_at": "2/3/2026 20:38:17"
+  },
+  {
+    "name": "Simon Revill",
+    "title": "Software Engineer",
+    "org": "",
+    "signed_at": "2/3/2026 22:29:36"
+  },
+  {
+    "name": "Tsvetan Tsvetanov",
+    "title": "Co-Owner and Lead Software Engineer",
+    "org": "Camplight",
+    "signed_at": "2/3/2026 22:54:35"
+  },
+  {
+    "name": "Jake McDonough ",
+    "title": "Founder ",
+    "org": "SAEONYX GLOBAL HOLDINGS, LLC",
+    "signed_at": "2/4/2026 2:11:41"
+  },
+  {
+    "name": "Frank Gerhardt",
+    "title": "",
+    "org": "",
+    "signed_at": "2/4/2026 9:28:41"
+  },
+  {
+    "name": "Alexandre Poitevin",
+    "title": "CTO / CPTO / Tech Lead / Software Engineer",
+    "org": "AlexandreSoftware",
+    "signed_at": "2/4/2026 9:43:36"
+  },
+  {
+    "name": "Marcin Mroczkowski",
+    "title": "Java Developer",
+    "org": "",
+    "signed_at": "2/4/2026 10:28:52"
+  },
+  {
+    "name": "Laurie Scheepers",
+    "title": "Technical Director",
+    "org": "ENTER Konsult",
+    "signed_at": "2/4/2026 13:16:30"
+  },
+  {
+    "name": "Konstantin Ignatyev",
+    "title": "Software Architect",
+    "org": "",
+    "signed_at": "2/4/2026 14:44:47"
+  },
+  {
+    "name": "Johan Schoubben",
+    "title": "Java Developer",
+    "org": "",
+    "signed_at": "2/4/2026 22:50:21"
+  },
+  {
+    "name": "Vitaly Sharovatov",
+    "title": "Developer Advocate",
+    "org": "Qase",
+    "signed_at": "2/4/2026 22:58:25"
+  },
+  {
+    "name": "Frank Ray",
+    "title": "Director",
+    "org": "Better Software UK",
+    "signed_at": "2/5/2026 1:55:38"
+  },
+  {
+    "name": "Thomas Dreyer",
+    "title": "Full Stack Software Engineer",
+    "org": "Independant",
+    "signed_at": "2/5/2026 3:22:40"
+  },
+  {
+    "name": "Brandon Casci",
+    "title": "",
+    "org": "Self",
+    "signed_at": "2/5/2026 10:11:22"
+  },
+  {
+    "name": "Martin Rosén-Lidholm",
+    "title": "VP of Product & Engineering",
+    "org": "ChronosHub",
+    "signed_at": "2/5/2026 13:13:07"
+  },
+  {
+    "name": "Michaeljohn Clement",
+    "title": "programmer, AI researcher",
+    "org": "cmpr.ai",
+    "signed_at": "2/5/2026 21:31:06"
+  },
+  {
+    "name": "James Herr",
+    "title": "Full Stack Engineer",
+    "org": "",
+    "signed_at": "2/6/2026 10:29:37"
+  },
+  {
+    "name": "Raimund Krämer",
+    "title": "Software Developer/Architect/Consultant",
+    "org": "",
+    "signed_at": "2/7/2026 0:40:41"
+  },
+  {
+    "name": "Jonathan Gruber",
+    "title": "Undergraduate Student",
+    "org": "The University of Texas at Dallas",
+    "signed_at": "2/7/2026 9:48:01"
+  },
+  {
+    "name": "István Hegedűs",
+    "title": "Principal Engineer",
+    "org": "",
+    "signed_at": "2/7/2026 10:43:38"
+  },
+  {
+    "name": "Gregor Riegler ",
+    "title": "Technical Coach",
+    "org": "",
+    "signed_at": "2/7/2026 10:54:30"
+  },
+  {
+    "name": "Peter Church",
+    "title": "CTO and Co-Founder ",
+    "org": "Darkhouse Enterprises Ltd",
+    "signed_at": "2/7/2026 11:35:40"
+  },
+  {
+    "name": "Nicolas Rosado",
+    "title": "Senior Software Engineer",
+    "org": "",
+    "signed_at": "2/7/2026 18:42:43"
+  },
+  {
+    "name": "Sergiu Ghita",
+    "title": "Software Quality Engineer",
+    "org": "",
+    "signed_at": "2/8/2026 0:47:10"
+  },
+  {
+    "name": "Sergio Sastre Florez",
+    "title": "Software Engineer",
+    "org": "",
+    "signed_at": "2/8/2026 3:46:11"
+  },
+  {
+    "name": "Lars-Erik Aabech",
+    "title": "Expert Generalist Software Engineer",
+    "org": "Aabech Consulting",
+    "signed_at": "2/8/2026 5:33:18"
+  },
+  {
+    "name": "Garrick West",
+    "title": "XP Coach & Software Developer",
+    "org": "",
+    "signed_at": "2/9/2026 6:35:36"
+  },
+  {
+    "name": "Arash Dorandish",
+    "title": "Solutions Architect ",
+    "org": "",
+    "signed_at": "2/9/2026 18:38:16"
+  },
+  {
+    "name": "Grygorii Kvasha",
+    "title": "Software architect",
+    "org": "",
+    "signed_at": "2/10/2026 14:44:17"
+  },
+  {
+    "name": "Kenneth Keck",
+    "title": "Software Engineer",
+    "org": "",
+    "signed_at": "2/15/2026 0:29:52"
+  },
+  {
+    "name": "Paul Kiat",
+    "title": "Full Stack Engineer",
+    "org": "Systone",
+    "signed_at": "2/25/2026 21:38:02"
+  },
+  {
+    "name": "Shoyeb Inamdar",
+    "title": "Lead Developer",
+    "org": "Dassault Systemes",
+    "signed_at": "2/26/2026 20:09:09"
+  },
+  {
+    "name": "Palash Lambhate",
+    "title": "",
+    "org": "",
+    "signed_at": "2/26/2026 21:29:44"
+  },
+  {
+    "name": "marcel.meyer@m2-consulting.io",
+    "title": "Founder & AI Engineer",
+    "org": "m2-consulting",
+    "signed_at": "3/4/2026 7:41:49"
+  },
+  {
+    "name": "Jona M.J. Heidsick",
+    "title": "",
+    "org": "",
+    "signed_at": "3/5/2026 9:13:36"
+  },
+  {
+    "name": "Martin Zokov",
+    "title": "Senior software engineer and Consultant",
+    "org": "",
+    "signed_at": "3/5/2026 12:25:31"
+  },
+  {
+    "name": "Robin Betts",
+    "title": "Principal Engineer",
+    "org": "",
+    "signed_at": "3/8/2026 23:58:47"
+  },
+  {
+    "name": "Emmz Rendle",
+    "title": "Veteran Software Builder",
+    "org": "",
+    "signed_at": "3/9/2026 4:37:05"
+  },
+  {
+    "name": "Eric Wright (@DiscoPosse)",
+    "title": "Chief Content Officer @ GTM Delta + Systems Architect for 30+years",
+    "org": "GTM Delta",
+    "signed_at": "3/11/2026 9:25:30"
+  },
+  {
+    "name": "Richard Williams ",
+    "title": "AI Engineering Splutions Architect",
+    "org": "Engineer For AI",
+    "signed_at": "3/15/2026 15:47:58"
+  },
+  {
+    "name": "John DuCrest",
+    "title": "Founder",
+    "org": "SYMBEYOND AI LLC",
+    "signed_at": "3/16/2026 13:39:22"
+  },
+  {
+    "name": "Kelly Hohman",
+    "title": "Founder",
+    "org": "Airtrek.ai",
+    "signed_at": "3/16/2026 15:36:26"
+  },
+  {
+    "name": "Simon Gant",
+    "title": "Ai Native",
+    "org": "Ai Native solutions",
+    "signed_at": "3/16/2026 18:05:41"
+  },
+  {
+    "name": "scott gardner",
+    "title": "founder",
+    "org": "ninja.ing",
+    "signed_at": "3/17/2026 10:51:43"
+  },
+  {
+    "name": "Dave Lush",
+    "title": "CTO & Co-Founder",
+    "org": "woti",
+    "signed_at": "3/23/2026 10:32:36"
+  },
+  {
+    "name": "Richard MEyer",
+    "title": "owner",
+    "org": "Similaritywave Technology",
+    "signed_at": "3/25/2026 20:18:08"
+  },
+  {
+    "name": "Craig Miller",
+    "title": "Founder",
+    "org": "ChiefofStaff",
+    "signed_at": "3/26/2026 6:27:14"
+  },
+  {
+    "name": "Shoyeb Inamdar",
+    "title": "Research and Development Manager",
+    "org": "Dassault Systemes",
+    "signed_at": "3/27/2026 9:10:26"
+  },
+  {
+    "name": "David Susanto",
+    "title": "Founder",
+    "org": "DoZe.ninja",
+    "signed_at": "3/28/2026 13:57:02"
+  },
+  {
+    "name": "Kaylee Burch",
+    "title": "Web Developer",
+    "org": "Independent",
+    "signed_at": "4/6/2026 13:16:11"
+  },
+  {
+    "name": "Fabio De Odorico",
+    "title": "Senior Software Engineer",
+    "org": "ENTER Konsult",
+    "signed_at": "4/7/2026 4:48:27"
+  },
+  {
+    "name": "Whit Whitman",
+    "title": "CEO",
+    "org": "PieoSync, LLC",
+    "signed_at": "4/7/2026 9:40:26"
+  },
+  {
+    "name": "Hermann Kuschke",
+    "title": "Tech Lead / Project Manager",
+    "org": "Windhoek Consulting Engineers",
+    "signed_at": "4/8/2026 19:50:40"
+  }
+]


### PR DESCRIPTION
## Summary

Move the signatories list from a public Google Sheet CSV fetch to a data file checked into the repo. The form still submits to the sheet; curators promote an entry into the data file via PR, so the rendered list stays a curated set rather than a live mirror of arbitrary form submissions.

**Why**: the current code fetches a CSV from the public sheet on every page load and renders every row as a card. A stray paste or unexpected submission propagates straight to the live site with no review step, and edits to the sheet can be masked by browser and gviz caches for an hour or more. Baking the list into the repo makes every change a reviewable commit and gives us a permanent history.

## What changed

- `signatories.json` — 57 entries seeded from the current sheet (`timestamp`, `name`, `title`, `org`). Emails are not mirrored into the public JSON.
- `index.html` — `loadSignatories()` now fetches `signatories.json` with a cache-busting query param and `{cache: 'no-store'}`, so admin edits propagate on the next page load.
- Defence-in-depth filter: rows whose `name` / `title` / `org` contain a URL are not rendered. URLs in those fields are always paste artefacts, not identity. Same filter shape as #29.
- Form success message updated to `"will appear once reviewed"` to match the new workflow.
- Removed the post-submit auto-reload (no longer meaningful — signatures don't appear until promoted to the JSON) and the unused `parseCSV` helper.

## Workflow for adding new signatories after merge

1. Someone signs via the form → the row lands in the sheet as before.
2. A maintainer reviews the row.
3. Maintainer adds an entry to `signatories.json` via a PR (name, title, org, signed_at).
4. Merge → the new signatory shows on the next page load.

## JSON vs YAML

The plan was "YAML", but the repo has no Jekyll / build step (commit `0064925` removed the workflows). Adding Jekyll just to parse YAML is more architectural change than this PR should carry, and browsers parse JSON natively. If a YAML source of truth is preferred, that is a separate PR that adds Jekyll and a `_data/signatories.yml`; this PR keeps the change shape minimal.

## Relation to #29

This PR supersedes #29. If this one is merged first, #29 can be closed as subsumed; its cache-busting + URL-filter changes are included here and applied against the new data source.

## Test plan

- [ ] Merge and hard-reload `index.html`; the 57 signatories render as before.
- [ ] A row edited or removed in `signatories.json` shows the new state on next page load without waiting for any cache TTL.
- [ ] A JSON entry with a URL in its name/title/org field does not render.
- [ ] Form submission still succeeds and shows the updated confirmation copy.