### PR TITLE
Update Laurie Scheepers profile — CodeTonight, IP stack, direct email

### DIFF
--- a/laurie-scheepers.html
+++ b/laurie-scheepers.html
@@ -61,7 +61,7 @@
                     </p>
 
                     <p>
-                        My day job is serving as the technical director at ENTER Konsult, our lean advanced tech firm. We transform industries that modern software has underserved, building long-term relationships to guide organisations through this revolutionary era. We make technology work FOR people -- not against the humans who make any organisation what it actually is. We also develop private, bespoke software for select people and organisations.
+                        My day job is serving as the technical director at CodeTonight, our lean advanced tech firm. We transform industries that modern software has underserved, building long-term relationships to guide organisations through this revolutionary era. We make technology work FOR people -- not against the humans who make any organisation what it actually is. We also develop private, bespoke software for select people and organisations.
                     </p>
 
                     <div class="member-tags" aria-label="Areas of practice">
@@ -82,8 +82,22 @@
                         <li>We extend our thinking -- never outsource it</li>
                     </ul>
 
+                    <p><strong>What we build.</strong></p>
+                    <p>
+                        CodeTonight builds its own AI, in layers. <strong>HAPPI</strong> is our open, provider-agnostic standard for talking to any model -- AI as a syscall, so a caller asks for inference without ever binding to one vendor's SDK. <strong>HAL</strong> is the runtime that speaks HAPPI to any provider, with automatic failover. <strong>GRIP</strong> is the agentic reasoning engine on top -- convergence, recursive self-improvement under human gates, and mechanical safety. And <strong>GRASP</strong> -- Governed Reasoning And Signable Provenance -- is the proof layer: signed, replayable records of what an AI decided, what it believed when it decided, and whether every claim it made is verbatim-present in its cited source. A sceptic can verify all of it independently; the verifier is the math, never us. The <strong>HAPPIverse</strong> is the network these nodes join, each publishing its own signed, witnessable chain.
+                    </p>
+                    <p>
+                        What is open, and what is licensed: <strong>HAPPI is an open, provider-agnostic standard with MIT-licensed SDKs, and GRASP -- the proof layer -- is open source under AGPL-3.0.</strong> Both are free; clone them and verify the moat yourself. <strong>GRIP (the engine) and HAL (the runtime) are private and licensed -- GRIP by invitation, never a download.</strong> The standard is yours to take; the runtime that makes it fast is ours to license.
+                    </p>
+                    <div class="member-tags" aria-label="The stack">
+                        <span>HAPPI &mdash; open standard (MIT)</span>
+                        <span>GRASP &mdash; open proof layer (AGPL-3.0)</span>
+                        <span>GRIP + HAL &mdash; licensed engine</span>
+                        <span>HAPPIverse &mdash; the network</span>
+                    </div>
+
                     <p class="member-contact">
-                        <a href="https://enterkonsult.com">enterkonsult.com</a>
+                        <a href="https://codetonight-sa.github.io">codetonight-sa.github.io</a>
                     </p>
 
                     <p>
@@ -141,7 +155,7 @@
                         I'm based in Cape Town, South Africa 🇿🇦 -- the city with the best weather in the world. This is not opinion. This is data. Come visit and argue with me about it over coffee.
                     </p>
                     <p>
-                        You can contact me anytime on the Discord channel.
+                        You can contact me anytime at laurie@codetonight.co.za.
                     </p>
                     <p class="member-signoff">Kind regards,<br>V&gt;&gt;</p>
                 </div>


### PR DESCRIPTION
## What this does (plain English)

Updates the founding-member profile for Laurie Scheepers to reflect where the work actually lives now.

- **ENTER Konsult → CodeTonight.** The firm reference and website link are updated; we're retiring enterkonsult.com.
- **Contact.** The Discord line is replaced with a direct email: laurie@codetonight.co.za.
- **New "What we build" section** describing the IP stack and how the pieces fit together — GRIP (the agentic reasoning engine), HAL (the any-model runtime), HAPPI (the open standard for talking to any model), GRASP (the open proof layer), and the HAPPIverse (the network these nodes join) — and, importantly, **what is open source versus licensed**: HAPPI (MIT) and GRASP (AGPL-3.0) are free and open; the GRIP + HAL engine is licensed by invitation.

All personal prose is otherwise unchanged.

## Accuracy

Licensing claims checked against the canonical repo state: HAPPI SDKs are MIT + public, `grasp` is AGPL-3.0 + public, GRIP and HAL are private/licensed. GRASP is described within its true scope (it proves a quoted claim is verbatim-present in its cited source).

## Test plan

- [ ] Profile renders with the new "What we build" section
- [ ] enterkonsult.com is no longer referenced anywhere on the page
- [ ] Email link and codetonight-sa.github.io link resolve
